### PR TITLE
Automatable cloud in a bottle (with deployers)

### DIFF
--- a/src/main/java/com/killerqu/compressiontweaks/config/CTCommonConfig.java
+++ b/src/main/java/com/killerqu/compressiontweaks/config/CTCommonConfig.java
@@ -7,11 +7,19 @@ public class CTCommonConfig {
     public static final ForgeConfigSpec SPEC;
 
     public static final ForgeConfigSpec.ConfigValue<Boolean> BOULDER_COMPASS;
+    public static final ForgeConfigSpec.ConfigValue<Integer> CLOUD_BOTTLING_MIN_Y;
+    public static final ForgeConfigSpec.ConfigValue<Integer> CLOUD_BOTTLING_MAX_Y;
 
     static {
         BUILDER.push("CompressionTweaks Config");
+
         BOULDER_COMPASS = BUILDER.comment("Whether to enable the AE2 meteor compass to also track tagged blocks spawned in jigsaw structures. Note that disabling this option down the line cannot automatically cleanup existing targets.")
                 .define("Enable Boulder Compass", true);
+        CLOUD_BOTTLING_MIN_Y = BUILDER.comment("The minimum y-level where bottling up clouds is possible")
+                        .define("Cloud in a Bottle Minimum Y-Level", 191);
+        CLOUD_BOTTLING_MAX_Y = BUILDER.comment("The maximum y-level where bottling up clouds is possible")
+                .define("Cloud in a Bottle Maximum Y-Level", 196);
+
         BUILDER.pop();
         SPEC = BUILDER.build();
     }

--- a/src/main/java/com/killerqu/compressiontweaks/mixin/CloudBottlingMixin.java
+++ b/src/main/java/com/killerqu/compressiontweaks/mixin/CloudBottlingMixin.java
@@ -1,0 +1,36 @@
+package com.killerqu.compressiontweaks.mixin;
+
+import com.killerqu.compressiontweaks.config.CTCommonConfig;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BottleItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import vazkii.quark.content.tools.module.BottledCloudModule;
+
+//This mixin is to allow the cloud in a bottle to be created by the bottle's use method instead of a player interact event.
+//This way, the process can be automated with a deployer. If someone asks, no, doing it with dispensers is a lot more complex.
+@Mixin(BottleItem.class)
+public class CloudBottlingMixin {
+    @Inject(method = "use", at = @At("RETURN"), cancellable = true)
+    private void getCloudInABottle(Level level, Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResultHolder<ItemStack>> cir){
+        InteractionResultHolder<ItemStack> resultHolder = cir.getReturnValue();
+        //PASS is the case where nothing happens. If something did happen, don't do anything else.
+        //This is actually inverted from quark's logic, where the cloud bottling takes priority.
+        if(resultHolder.getResult() != InteractionResult.PASS) return;
+        if(player.getY() > CTCommonConfig.CLOUD_BOTTLING_MIN_Y.get() && player.getY() < CTCommonConfig.CLOUD_BOTTLING_MAX_Y.get()){
+            resultHolder.getObject().shrink(1);
+            //TODO: Evaluate whether it's worth it to ditch the quark dependency and replace this with a call to forge registries
+            ItemStack bottledCloud = new ItemStack(BottledCloudModule.bottled_cloud);
+            //It's how quark does it.
+            if(!player.addItem(bottledCloud)) player.drop(bottledCloud, false);
+            cir.setReturnValue(InteractionResultHolder.success(resultHolder.getObject()));
+        }
+    }
+}

--- a/src/main/resources/compressiontweaks.mixins.json
+++ b/src/main/resources/compressiontweaks.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_8",
   "refmap": "compressiontweaks.refmap.json",
   "mixins": [
+    "CloudBottlingMixin",
     "CompassServiceMixin",
     "RemainingItemMixin",
     "StructureMixin"


### PR DESCRIPTION
Lets deployers make the cloud in a bottle.
This can coexist with quark's own logic, which will take priority when a player tries to make the cloud in a bottle.