### PR TITLE
Patch EMI's hardcoded elytra repair recipe to use Property Modifier's tag instead.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,10 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    maven {
+        name = "TerraformersMC"
+        url = "https://maven.terraformersmc.com/"
+    }
 }
 
 dependencies {
@@ -189,6 +193,8 @@ dependencies {
     implementation fg.deobf("appeng:appliedenergistics2-forge:12.9.5")
     //This is...not required for now. I'll figure out something for that damn cloud in a bottle eventually.
     implementation fg.deobf("vazkii.quark:Quark:3.4-408.3077")
+    compileOnly fg.deobf("dev.emi:emi-forge:${emi_version}")
+    runtimeOnly fg.deobf("dev.emi:emi-forge:${emi_version}")
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ mod_name=CompressionTweaks
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.1.0
+mod_version=1.1.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
@@ -56,3 +56,4 @@ flywheel_minecraft_version = 1.19.2
 create_version = 0.5.1.e-44
 flywheel_version = 0.6.10-20
 registrate_version = MC1.19-1.1.5
+emi_version = 1.1.22+1.19.2

--- a/src/main/java/com/killerqu/compressiontweaks/mixin/EMIVanillaMixin.java
+++ b/src/main/java/com/killerqu/compressiontweaks/mixin/EMIVanillaMixin.java
@@ -1,0 +1,47 @@
+package com.killerqu.compressiontweaks.mixin;
+
+import dev.emi.emi.EmiUtil;
+import dev.emi.emi.VanillaPlugin;
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.recipe.EmiAnvilRecipe;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+//This mixin alters the hardcoded repair recipes in EMI for elytras and shields to use the tags from Property Modifier
+@Mixin(VanillaPlugin.class)
+public abstract class EMIVanillaMixin {
+
+    @Shadow(remap = false)
+    protected static ResourceLocation synthetic(String type, String name) {
+        return null;
+    }
+
+    @Unique
+    private static final TagKey<Item> ELYTRA_REPAIR_MATERIALS = ItemTags.create(new ResourceLocation("propertymodifier", "elytra_repair_material"));
+    @Unique
+    private static final TagKey<Item> SHIELD_REPAIR_MATERIALS = ItemTags.create(new ResourceLocation("propertymodifier", "shield_repair_material"));
+
+    //These two target the specific suppliers to actually make the EmiAnvilRecipe. So we just cancel them with the "correct" ones.
+    @Inject(method = "lambda$addRepair$42", at = @At(value = "HEAD"), remap = false, cancellable = true)
+    private static void changeElytraRepairMaterial(CallbackInfoReturnable<EmiRecipe> cir){
+        cir.setReturnValue(new EmiAnvilRecipe(EmiStack.of(Items.ELYTRA), EmiIngredient.of(ELYTRA_REPAIR_MATERIALS),
+                synthetic("anvil/repairing/material", EmiUtil.subId(Items.ELYTRA) + "/" + EmiUtil.subId(Items.PHANTOM_MEMBRANE))));
+    }
+    @Inject(method = "lambda$addRepair$43", at = @At(value = "HEAD"), remap = false, cancellable = true)
+    private static void changeShieldRepairMaterial(CallbackInfoReturnable<EmiRecipe> cir){
+        cir.setReturnValue(new EmiAnvilRecipe(EmiStack.of(Items.SHIELD), EmiIngredient.of(SHIELD_REPAIR_MATERIALS),
+                synthetic("anvil/repairing/material", EmiUtil.subId(Items.SHIELD) + "/" + EmiUtil.subId(Items.OAK_PLANKS))));
+    }
+
+}

--- a/src/main/resources/compressiontweaks.mixins.json
+++ b/src/main/resources/compressiontweaks.mixins.json
@@ -11,7 +11,8 @@
     "compass.StructureMixin"
   ],
   "client": [
-    "bottled_cloud.JEIConversionCategoryMixin"
+    "bottled_cloud.JEIConversionCategoryMixin",
+    "EMIVanillaMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Mixed into EMI to change the hardcoded repair recipes for elytra and shield to use Property Modifier's tags